### PR TITLE
Added RegExp validation for thanks/kudos listener

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devmod",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "description": "The latest in a series of rewrites for devmod, a bot meant for moderation of discord servers, specifically devcord.",
   "main": "src/main.js",
   "types": "module",

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 # devmod
-> v5.0.0
+> v5.1.0
 
 > A Discord bot for moderating servers.
 

--- a/src/processes/thanksListener.js
+++ b/src/processes/thanksListener.js
@@ -21,7 +21,7 @@ export const initThanksListener = async client => {
          * 
          * Has a lot of edge case tests :)
          */
-        if (message.channel.type !== 'dm' && !message.author.bot && message.content.match(/(?<=^thanks?.*|^kudos.*)(?<=\s)@[^\n#]+#\d{4}\b/gi).length > 0) {
+        if (message.channel.type !== 'dm' && !message.author.bot && message.content.match(/(?<=^thanks?.*|^kudos.*)(?<=\s)@[^\n#]+#\d{4}\b/gi) !== null) {
           // Get the member thanked and filter for undefined members.
           const thankees = message.mentions.members.filter(thankee => thankee !== undefined)
 

--- a/src/processes/thanksListener.js
+++ b/src/processes/thanksListener.js
@@ -15,7 +15,13 @@ export const initThanksListener = async client => {
     client.on('message', async message => {
       try {
         // If the message isn't a dm, the author isn't a bot, and it contains the word 'thank' or 'kudos', continue.
-        if (message.channel.type !== 'dm' && !message.author.bot && ['thank', 'kudos'].some(t => message.content.toLowerCase().includes(t))) {
+
+        /**
+         * Matching the following RegExp: https://regex101.com/r/aR3sc1/22
+         * 
+         * Has a lot of edge case tests :)
+         */
+        if (message.channel.type !== 'dm' && !message.author.bot && message.content.match(/(?<=^thanks?.*|^kudos.*)(?<=\s)@[^\n#]+#\d{4}\b/gi).length > 0) {
           // Get the member thanked and filter for undefined members.
           const thankees = message.mentions.members.filter(thankee => thankee !== undefined)
 


### PR DESCRIPTION
I was getting annoyed that I couldn't thank people without them getting rep (even when it is not intentional) so I set out to make a very dynamic RegExp that fits all appropriate use cases but ignores generic thanks to other members.

You can see the 22 iterations of the expression with a list of edge cases here:
https://regex101.com/r/aR3sc1/22

I also updated the ReadME since the version it displayed was not correct.

Relevant: https://discordapp.com/channels/174075418410876928/621385120229621821/624352366006894612

Any issues let me know and I am happy to append :)