### PR TITLE
MDN Command

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.tabSize": 2,
+}

--- a/docs/mdn.md
+++ b/docs/mdn.md
@@ -1,0 +1,12 @@
+# MDN
+
+## Usage
+`.mdn <search query>`
+
+Searches MDN and returns the first result.
+
+## Permission Requirements
+`['SEND_MESSAGES']`
+
+## Author
+**devmod** © [RedXTech](https://github.com/redxtech), Released under the [MIT](../LICENSE.md) License.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,6 +11,7 @@
 - [Help](./help.md)
 - [LMGTFY](./lmgtfy.md)
 - [Lock](./lock.md)
+- [MDN](./mdn.md)
 - [Move](./move.md)
 - [Mute](./mute.md)
 - [Ping](./ping.md)

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -14,6 +14,7 @@ import { helpCommand } from './help'
 import { killCommand } from './kill'
 import { lmgtfyCommand } from './lmgtfy'
 import { lockCommand } from './lock'
+import { mdnCommand } from './mdn'
 import { moveCommand } from './move'
 import { muteCommand } from './mute'
 import { pingCommand } from './ping'
@@ -43,6 +44,7 @@ export const commandsArray = [
   killCommand,
   lmgtfyCommand,
   lockCommand,
+  mdnCommand,
   moveCommand,
   muteCommand,
   pingCommand,

--- a/src/commands/mdn.js
+++ b/src/commands/mdn.js
@@ -1,0 +1,71 @@
+import https from 'https'
+
+import { blue } from '../utils/colours'
+import { logError } from '../utils/log'
+import { getAuthor } from '../utils/user'
+
+const mdn = query => new Promise((resolve, reject) => {
+  https.get(
+    `https://developer.mozilla.org/api/v1/${query}`,
+
+    res => {
+      const chunks = []
+
+      res.on('data', chunk => chunks.push(chunk))
+
+      res.on('end', () => {
+        try {
+          resolve(JSON.parse(chunks.join('')))
+        } catch (error) {
+          reject(error)
+        }
+      })
+    }
+  ).on('error', reject)
+})
+
+export const mdnCommand = {
+  name: 'MDN',
+  aliases: ['mdn'],
+  category: 'utils',
+  description: 'Searches MDN and returns the first result.',
+  permissions: ['SEND_MESSAGES'],
+
+  exec: async (args, message) => {
+    const query = encodeURIComponent(args.join(' '))
+
+    try {
+      // Query the MDN search API
+      const { documents } = await mdn(`search/en-US?q=${query}&highlight=false`)
+      const [result] = documents
+
+      try {
+        // Remove the user's message.
+        await message.delete()
+      } catch (err) {
+        await logError('MDN', 'Failed to delete message', err, message)
+      }
+
+      try {
+        // Send the MDN result.
+        // noinspection JSUnresolvedFunction
+        return message.channel.send({
+          embed: {
+            title: result.title,
+            color: blue,
+            description:
+`...${result.excerpt}...
+
+[Search on MDN](https://developer.mozilla.org/en-US/search?q=${query})`,
+            author: getAuthor(message.member),
+            url: `https://developer.mozilla.org/en-US/${result.slug}`
+          }
+        })
+      } catch (err) {
+        await logError('MDN', 'Failed to send message', err, message)
+      }
+    } catch (err) {
+      await logError('MDN', `Failed to search MDN for query "${query}"`, err, message)
+    }
+  }
+}


### PR DESCRIPTION
This pull request contains the `.mdn` command used for querying [MDN](https://developer.mozilla.org/). I wrote the fetch script with the native `https` module as to not create any new dependencies.

![image](https://cdn.discordapp.com/attachments/443678023720370176/656964901759352842/unknown.png)

PS: Added a `.vscode` configuration to set up the compliant 2 space indent size, forgot to make a separate pull request.