### PR TITLE
Users can react 0-9 to .MDN to flip through results

### DIFF
--- a/src/commands/mdn.js
+++ b/src/commands/mdn.js
@@ -10,10 +10,23 @@ import { logError } from '../utils/log'
 import { getAuthor } from '../utils/user'
 import { sendErrorMessage } from '../utils/sendErrorMessage'
 
+const emotes = [
+  '0️⃣',
+  '1️⃣',
+  '2️⃣',
+  '3️⃣',
+  '4️⃣',
+  '5️⃣',
+  '6️⃣',
+  '7️⃣',
+  '8️⃣',
+  '9️⃣'
+]
+
 // Function to query mdn and return the result
 const queryMDN = query => new Promise((resolve, reject) => {
   https.get(
-    `https://developer.mozilla.org/api/v1/${query}`,
+    `https://developer.mozilla.org/api/v1/search/en-US?q=${query}&highlight=false`,
 
     res => {
       const chunks = []
@@ -49,7 +62,7 @@ export const mdnCommand = {
 
     try {
       // Query the MDN search API
-      const { documents } = await queryMDN(`search/en-US?q=${query}&highlight=false`)
+      const { documents } = await queryMDN(query)
       const [result] = documents
 
       try {
@@ -73,6 +86,10 @@ export const mdnCommand = {
             author: getAuthor(message.member),
             url: `https://developer.mozilla.org/en-US/${result.slug}`
           }
+        }).then(message=>{
+          emotes.forEach(emote=>{
+            message.react(emote)
+          })
         })
       } catch (err) {
         await logError('MDN', 'Failed to send message', err, message)

--- a/src/commands/mdn.js
+++ b/src/commands/mdn.js
@@ -13,7 +13,7 @@ import { sendErrorMessage } from '../utils/sendErrorMessage'
 // Function to query mdn and return the result
 const queryMDN = query => new Promise((resolve, reject) => {
   https.get(
-    `https://developer.mozilla.org/api/v1/${query}`,
+    `https://developer.mozilla.org/api/v1/search/en-US?q=${query}&highlight=false`,
 
     res => {
       const chunks = []
@@ -49,7 +49,7 @@ export const mdnCommand = {
 
     try {
       // Query the MDN search API
-      const { documents } = await queryMDN(`search/en-US?q=${query}&highlight=false`)
+      const { documents } = await queryMDN(query)
       const [result] = documents
 
       try {


### PR DESCRIPTION
Often the first result of the MDN query is not the desired one. Flipping through the results is the easiest and most compact way of displaying multiple results. I have made the bot react with [0] through [9] after sending its reply. Now it needs to detect users clicking on these reactions and display the appropriate result.