### PR TITLE
Suggestion fix for "thanks" bot command

### DIFF
--- a/src/processes/thanksListener.js
+++ b/src/processes/thanksListener.js
@@ -18,7 +18,7 @@ export const initThanksListener = async client => {
     client.on('message', async message => {
       try {
         // If the message isn't a dm, the author isn't a bot, and it contains the word 'thank' or 'kudos', continue.
-        if (message.channel.type !== 'dm' && !message.author.bot && ['thank', 'kudos'].some(t => message.content.toLowerCase().includes(t))) {
+        if (message.channel.type !== 'dm' && !message.author.bot && ['.thank', 'kudos'].some(t => message.content.toLowerCase().includes(t))) {
           // Get the member thanked and filter for undefined members.
           const thankees = message.mentions.members.filter(thankee => thankee !== undefined)
 


### PR DESCRIPTION
Giving rep happens to often for no reason. Dot before `thanks` should solve this issue.